### PR TITLE
chore: bump test packages to latest

### DIFF
--- a/test/NosCore.Algorithm.Tests/NosCore.Algorithm.Tests.csproj
+++ b/test/NosCore.Algorithm.Tests/NosCore.Algorithm.Tests.csproj
@@ -14,10 +14,10 @@
 
   <ItemGroup>
     <PackageReference Include="ApprovalTests" Version="7.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.7.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.7.0" />
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.2.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.2.1" />
+    <PackageReference Include="coverlet.collector" Version="10.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
## Summary
- `coverlet.collector` 6.0.4 → 10.0.0
- `Microsoft.NET.Test.Sdk` 18.0.1 → 18.4.0
- `MSTest.TestAdapter`/`MSTest.TestFramework` 3.7.0 → 4.2.1

All 20 unit tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)