### PR TITLE
chore: add local NuGet source via NOSCORE_LOCAL_PACKAGES env var

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
     <packageSources>
+        <add key="local" value="%NOSCORE_LOCAL_PACKAGES%" />
         <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
     </packageSources>
 </configuration>


### PR DESCRIPTION
## Summary
- Adds a `local` NuGet package source that reads the `NOSCORE_LOCAL_PACKAGES` environment variable.
- When the variable is unset the source resolves to nothing and `nuget.org` is used — contributors who don't opt in are unaffected.
- Set `NOSCORE_LOCAL_PACKAGES` to a folder (e.g. `C:\LocalPackages`) to consume unpublished `.nupkg` builds locally without editing `NuGet.config`.

## Test plan
- [ ] `dotnet restore` succeeds with `NOSCORE_LOCAL_PACKAGES` unset.
- [ ] `dotnet restore` succeeds with `NOSCORE_LOCAL_PACKAGES` pointing to a folder containing a `.nupkg` override.

Generated with [Claude Code](https://claude.com/claude-code)